### PR TITLE
#22: Add config file support by replacing argparse with configargparse

### DIFF
--- a/align_assist.py
+++ b/align_assist.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
 
+from config import *
 import track
 import mounts
 import errorsources
-import argparse
 import sys
 import time
 import math
 import numpy as np
 
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(default_config_files=DEFAULT_CFGFILES)
 parser.add_argument('--camera', help='device name of tracking camera', default='/dev/video0')
 parser.add_argument('--camera-res', help='camera resolution in arcseconds per pixel', required=True, type=float)
 parser.add_argument('--scope', help='serial device for connection to telescope', default='/dev/ttyUSB0')

--- a/align_assist.py
+++ b/align_assist.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-from config import *
+import config
+import configargparse
 import track
 import mounts
 import errorsources
@@ -10,7 +11,7 @@ import math
 import numpy as np
 
 
-parser = argparse.ArgumentParser(default_config_files=DEFAULT_CFGFILES)
+parser = configargparse.ArgParser(default_config_files=config.DEFAULT_FILES)
 parser.add_argument('--camera', help='device name of tracking camera', default='/dev/video0')
 parser.add_argument('--camera-res', help='camera resolution in arcseconds per pixel', required=True, type=float)
 parser.add_argument('--scope', help='serial device for connection to telescope', default='/dev/ttyUSB0')

--- a/backlash_estimate.py
+++ b/backlash_estimate.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
-from config import *
+import config
+import configargparse
 import track
 import mounts
 import errorsources
 import time
 import numpy as np
 
-parser = argparse.ArgumentParser(default_config_files=DEFAULT_CFGFILES)
+parser = configargparse.ArgParser(default_config_files=config.DEFAULT_FILES)
 parser.add_argument('--camera', help='device name of tracking camera', default='/dev/video0')
 parser.add_argument('--camera-res', help='camera resolution in arcseconds per pixel', required=True, type=float)
 parser.add_argument('--scope', help='serial device for connection to telescope', default='/dev/ttyUSB0')

--- a/backlash_estimate.py
+++ b/backlash_estimate.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
+from config import *
 import track
 import mounts
 import errorsources
-import argparse
 import time
 import numpy as np
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(default_config_files=DEFAULT_CFGFILES)
 parser.add_argument('--camera', help='device name of tracking camera', default='/dev/video0')
 parser.add_argument('--camera-res', help='camera resolution in arcseconds per pixel', required=True, type=float)
 parser.add_argument('--scope', help='serial device for connection to telescope', default='/dev/ttyUSB0')

--- a/blind_track.py
+++ b/blind_track.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 
-from config import *
+import config
+import configargparse
 import track
 import mounts
 import errorsources
 import ephem
 
-parser = argparse.ArgumentParser(default_config_files=DEFAULT_CFGFILES, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser = configargparse.ArgParser(default_config_files=config.DEFAULT_FILES, formatter_class=configargparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('tle', help='filename of two-line element (TLE) target ephemeris')
 parser.add_argument('--scope', help='serial device for connection to telescope', default='/dev/ttyUSB0')
 parser.add_argument('--lat', required=True, help='latitude of observer (+N)')

--- a/blind_track.py
+++ b/blind_track.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
+from config import *
 import track
 import mounts
 import errorsources
 import ephem
-import argparse
 
-parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser = argparse.ArgumentParser(default_config_files=DEFAULT_CFGFILES, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('tle', help='filename of two-line element (TLE) target ephemeris')
 parser.add_argument('--scope', help='serial device for connection to telescope', default='/dev/ttyUSB0')
 parser.add_argument('--lat', required=True, help='latitude of observer (+N)')

--- a/config.py
+++ b/config.py
@@ -1,6 +1,4 @@
-import configargparse as argparse
-
-DEFAULT_CFGFILES=[
+DEFAULT_FILES=[
     './track.cfg',
     '~/.track.cfg',
 ]

--- a/config.py
+++ b/config.py
@@ -1,0 +1,6 @@
+import configargparse as argparse
+
+DEFAULT_CFGFILES=[
+    './track.cfg',
+    '~/.track.cfg',
+]

--- a/optical_track.py
+++ b/optical_track.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
-from config import *
+import config
+import configargparse
 import track
 import mounts
 import errorsources
 
-parser = argparse.ArgumentParser(default_config_files=DEFAULT_CFGFILES)
+parser = configargparse.ArgParser(default_config_files=config.DEFAULT_FILES)
 parser.add_argument('--camera', help='device name of tracking camera', default='/dev/video0')
 parser.add_argument('--camera-res', help='camera resolution in arcseconds per pixel', required=True, type=float)
 parser.add_argument('--scope', help='serial device for connection to telescope', default='/dev/ttyUSB0')

--- a/optical_track.py
+++ b/optical_track.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
+from config import *
 import track
 import mounts
 import errorsources
-import argparse
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(default_config_files=DEFAULT_CFGFILES)
 parser.add_argument('--camera', help='device name of tracking camera', default='/dev/video0')
 parser.add_argument('--camera-res', help='camera resolution in arcseconds per pixel', required=True, type=float)
 parser.add_argument('--scope', help='serial device for connection to telescope', default='/dev/ttyUSB0')

--- a/slew_rate_test.py
+++ b/slew_rate_test.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 
-from config import *
+import config
+import configargparse
 import mounts
 import errorsources
 import time
 import numpy as np
 
-parser = argparse.ArgumentParser(default_config_files=DEFAULT_CFGFILES)
+parser = configargparse.ArgParser(default_config_files=config.DEFAULT_FILES)
 parser.add_argument('--scope', help='serial device for connection to telescope', default='/dev/ttyUSB0')
 args = parser.parse_args()
 

--- a/slew_rate_test.py
+++ b/slew_rate_test.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
+from config import *
 import mounts
 import errorsources
-import argparse
 import time
 import numpy as np
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(default_config_files=DEFAULT_CFGFILES)
 parser.add_argument('--scope', help='serial device for connection to telescope', default='/dev/ttyUSB0')
 args = parser.parse_args()
 


### PR DESCRIPTION
This may not necessarily be the most-ideal way to set it all up and configure it, but I've tested this and it does work. Probably tweak it to your liking if you have different ideas about how this should work.

https://pypi.python.org/pypi/ConfigArgParse
https://github.com/bw2/ConfigArgParse