### PR TITLE
Remove v4l2capture dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ Camera support uses the v4l2capture package which compiles C code. This code #in
 
 Something requires Python.h to compile. You will need to install the python3-dev package to make this header file available.
 
-Furthermore, the v4l2capture project has forked. This project requires a fork that is *not* registered in PyPi; it exists here instead: https://github.com/gebart/python-v4l2capture/. To ensure that this package is installed correctly, pass the --process-dependency-links option to pip:
+A patched version of the v4l2 package is required, since its maintainers are apparently deceased or otherwise incapacitated. A branch containing the patched version is available at https://bazaar.launchpad.net/~jgottula/python-v4l2/fix-for-bug-1664158/revision/31 and can alternatively be found here: https://github.com/bgottula/python-v4l2
+
+To ensure that the patched version of the v4l2 package mentioned above is installed, pass the --process-dependency-links option to pip:
 
 pip3 install --process-dependency-links .
-
-This will also be required to get a patched version of the v4l2 package, since the maintainers of that package are apparently deceased or otherwise incapacitated. The branch containing the patch is available here: https://bazaar.launchpad.net/~jgottula/python-v4l2/fix-for-bug-1664158/revision/31 and has also been forked and uploaded here: https://github.com/bgottula/python-v4l2

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Camera support uses the v4l2capture package which compiles C code. This code #in
 
 Something requires Python.h to compile. You will need to install the python3-dev package to make this header file available.
 
-A patched version of the v4l2 package is required, since its maintainers are apparently deceased or otherwise incapacitated. A branch containing the patched version is available at https://bazaar.launchpad.net/~jgottula/python-v4l2/fix-for-bug-1664158/revision/31 and can alternatively be found here: https://github.com/bgottula/python-v4l2
+A patched version of the v4l2 package is required, since it contains a number of bugs and its maintainers are apparently deceased or otherwise incapacitated. A branch containing the patched version is available here: https://github.com/bgottula/python-v4l2
 
 To ensure that the patched version of the v4l2 package mentioned above is installed, pass the --process-dependency-links option to pip:
 

--- a/setup.py
+++ b/setup.py
@@ -47,14 +47,12 @@ setup(
         'inputs>=0.1',
         'numpy',
         'v4l2==0.2.1',
-        'v4l2capture==1.5',
         'requests',
         'MonthDelta>=1.0b',
     ],
 
     dependency_links=[
         'https://github.com/bgottula/python-v4l2/tarball/master#egg=v4l2-0.2.1',
-        'https://github.com/gebart/python-v4l2capture/tarball/master#egg=v4l2capture-1.5',
         'https://github.com/bgottula/point/tarball/master#egg=point-0.1',
     ],
 

--- a/track/webcam.py
+++ b/track/webcam.py
@@ -205,6 +205,8 @@ class V4L2WebCam(object):
         result = self.buffers[buf.index].start.read(buf.bytesused)
         self.buffers[buf.index].start.seek(0)
 
+        self._v4l2_ioctl(v4l2.VIDIOC_QBUF, buf)
+
         return result
 
     def close(self):

--- a/track/webcam.py
+++ b/track/webcam.py
@@ -2,6 +2,7 @@ import os
 import fcntl
 import select
 import mmap
+import errno
 import ctypes
 import numpy as np
 import cv2
@@ -198,8 +199,8 @@ class WebCam(object):
     def _v4l2_ioctl_nonfatal(self, req, arg, err_msg):
         try:
             self._v4l2_ioctl(req, arg)
-        except (IOError, OSError):
+        except OSError:
             print('WebCam: {}'.format(err_msg))
 
     def _v4l2_ioctl(self, req, arg):
-        fcntl.ioctl(self.dev_fd, req, arg)
+        assert (fcntl.ioctl(self.dev_fd, req, arg) == 0)

--- a/track/webcam.py
+++ b/track/webcam.py
@@ -95,8 +95,7 @@ class WebCam(object):
 
 
     def _verify_capabilities(self):
-        fmt      = v4l2.v4l2_format()
-        fmt.type = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
+        fmt = v4l2.v4l2_format(type=v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE)
         self._v4l2_ioctl(v4l2.VIDIOC_G_FMT, fmt)
         # TODO: check whether VIDIOC_G_FMT is even the right IOCTL for determining POSSIBLE pixel formats
         #       and not just the current one
@@ -117,13 +116,11 @@ class WebCam(object):
     def _set_autogain(self, enable): self._set_ctrl(v4l2.V4L2_CID_AUTOGAIN, bool(enable), 'automatic gain')
 
     def _set_ctrl(self, id, value, desc):
-        ctrl       = v4l2.v4l2_control()
-        ctrl.id    = id
-        ctrl.value = value
+        ctrl = v4l2.v4l2_control(id=id, value=value)
         self._v4l2_ioctl_nonfatal(v4l2.VIDIOC_S_CTRL, ctrl, 'failed to set control: {}'.format(desc))
 
     def _set_jpeg_quality(self, quality):
-        jpegcomp         = v4l2.v4l2_jpegcompression()
+        jpegcomp = v4l2.v4l2_jpegcompression()
         self._v4l2_ioctl_nonfatal(v4l2.VIDIOC_G_JPEGCOMP, jpegcomp, 'failed to set JPEG compression quality')
         jpegcomp.quality = quality
         self._v4l2_ioctl_nonfatal(v4l2.VIDIOC_S_JPEGCOMP, jpegcomp, 'failed to set JPEG compression quality')
@@ -132,8 +129,7 @@ class WebCam(object):
     def _set_format(self, res_wanted, fourcc):
         assert (not self.started)
 
-        fmt      = v4l2.v4l2_format()
-        fmt.type = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
+        fmt = v4l2.v4l2_format(type=v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE)
         self._v4l2_ioctl(v4l2.VIDIOC_G_FMT, fmt)
 
         fmt.type                 = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
@@ -152,20 +148,13 @@ class WebCam(object):
         assert (not self.started)
         assert (len(self.bufmaps) == 0)
 
-        reqbuf        = v4l2.v4l2_requestbuffers()
-        reqbuf.count  = buf_count
-        reqbuf.type   = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
-        reqbuf.memory = v4l2.V4L2_MEMORY_MMAP
+        reqbuf = v4l2.v4l2_requestbuffers(type=v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE, count=buf_count, memory=v4l2.V4L2_MEMORY_MMAP)
         self._v4l2_ioctl(v4l2.VIDIOC_REQBUFS, reqbuf)
         assert (reqbuf.count > 0)
 
         for idx in range(reqbuf.count):
-            buf        = v4l2.v4l2_buffer()
-            buf.index  = idx
-            buf.type   = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
-            buf.memory = v4l2.V4L2_MEMORY_MMAP
+            buf = v4l2.v4l2_buffer(type=v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE, index=idx, memory=v4l2.V4L2_MEMORY_MMAP)
             self._v4l2_ioctl(v4l2.VIDIOC_QUERYBUF, buf)
-
             self.bufmaps += [mmap.mmap(self.dev_fd, buf.length, access=mmap.ACCESS_WRITE, offset=buf.m.offset)]
 
     # roughly equivalent to v4l2capture's queue_all_buffers
@@ -174,19 +163,14 @@ class WebCam(object):
         assert (len(self.bufmaps) != 0)
 
         for idx in range(len(self.bufmaps)):
-            buf        = v4l2.v4l2_buffer()
-            buf.index  = idx
-            buf.type   = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
-            buf.memory = v4l2.V4L2_MEMORY_MMAP
+            buf = v4l2.v4l2_buffer(type=v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE, index=idx, memory=v4l2.V4L2_MEMORY_MMAP)
             self._v4l2_ioctl(v4l2.VIDIOC_QBUF, buf)
 
     # roughly equivalent to v4l2capture's read_and_queue
     def _read_and_queue(self):
         assert (self.started)
 
-        buf        = v4l2.v4l2_buffer()
-        buf.type   = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
-        buf.memory = v4l2.V4L2_MEMORY_MMAP
+        buf = v4l2.v4l2_buffer(type=v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE, memory=v4l2.V4L2_MEMORY_MMAP)
         self._v4l2_ioctl(v4l2.VIDIOC_DQBUF, buf)
 
         frame = self.bufmaps[buf.index].read(buf.bytesused)

--- a/track/webcam.py
+++ b/track/webcam.py
@@ -1,65 +1,47 @@
+import os
 import fcntl
 import select
+import mmap
+import ctypes
+from collections import namedtuple
 import numpy as np
 import cv2
 import v4l2
-import v4l2capture # USE THIS FORK: https://github.com/gebart/python-v4l2capture
 
 
 class WebCam(object):
 
-    def __init__(self, dev_path, num_buffers, ctlval_exposure):
-        self.dev_path        = dev_path
-        self.num_buffers     = num_buffers
-        self.ctlval_exposure = ctlval_exposure
+    def __init__(self, dev_path, num_buffers, ctrlval_exposure):
+        self.dev_path    = dev_path
+        self.num_buffers = num_buffers
 
         # detect OpenCV version to handle API differences between 2 and 3
         self.opencv_ver = int(cv2.__version__.split('.')[0])
-        assert self.opencv_ver == 2 or self.opencv_ver == 3
+        assert (self.opencv_ver == 2 or self.opencv_ver == 3)
 
-        self.dev = open(self.dev_path, 'r')
+        self.dev_fd = os.open(self.dev_path, os.O_RDWR | os.O_NONBLOCK);
 
-        # set the JPEG compression quality to the maximum level possible
-        try:
-            jpegcomp = v4l2.v4l2_jpegcompression()
-            fcntl.ioctl(self.dev, v4l2.VIDIOC_G_JPEGCOMP, jpegcomp)
-            jpegcomp.quality = 100
-            fcntl.ioctl(self.dev, v4l2.VIDIOC_S_JPEGCOMP, jpegcomp)
-        except (IOError, OSError):
-            print('WebCam: failed to set control: JPEG compression quality')
+        self._set_exposure(ctrlval_exposure)
+        self._set_autogain(False)
+        self._set_jpeg_quality(100)
 
-        # disable automatic gain control
-        try:
-            ctrl = v4l2.v4l2_control()
-            ctrl.id    = v4l2.V4L2_CID_AUTOGAIN
-            ctrl.value = 0
-            fcntl.ioctl(self.dev, v4l2.VIDIOC_S_CTRL, ctrl)
-        except (IOError, OSError):
-            print('WebCam: failed to set control: automatic gain')
+        fmt = self._get_capture_format()
 
-        # set exposure to the desired level
-        try:
-            ctrl = v4l2.v4l2_control()
-            ctrl.id    = v4l2.V4L2_CID_EXPOSURE
-            ctrl.value = int(self.ctlval_exposure)
-            fcntl.ioctl(self.dev, v4l2.VIDIOC_S_CTRL, ctrl)
-        except (IOError, OSError):
-            print('WebCam: failed to set control: exposure')
-
+        # TODO: check whether VIDIOC_G_FMT is even the right IOCTL for determining POSSIBLE pixfmts and not just the current one
         # ensure that the device supports 'JFIF JPEG' format video capture
-        fmt = v4l2.v4l2_format()
-        fmt.type = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
-        fcntl.ioctl(self.dev, v4l2.VIDIOC_G_FMT, fmt)
-        assert (fmt.fmt.pix.pixelformat == v4l2.V4L2_PIX_FMT_JPEG)
+        assert (fmt.pix.pixelformat == v4l2.V4L2_PIX_FMT_JPEG)
 
+        # TODO: check whether VIDIOC_G_FMT is even the right IOCTL for determining POSSIBLE resolutions and not just the current one
         # sanity-check the allegedly supported camera width and height
-        assert (fmt.fmt.win.w.left > 0 and fmt.fmt.win.w.left <= 10240)
-        assert (fmt.fmt.win.w.top  > 0 and fmt.fmt.win.w.top  <= 10240)
-        self.res_wanted = (fmt.fmt.win.w.left, fmt.fmt.win.w.top)
+        assert (fmt.win.w.left > 0 and fmt.win.w.left <= 10240)
+        assert (fmt.win.w.top  > 0 and fmt.win.w.top  <= 10240)
+        self.res_wanted = (fmt.win.w.left, fmt.win.w.top)
 
-        self.camera = v4l2capture.Video_device(self.dev_path)
+        self.camera = V4L2WebCam(self.dev_fd)
 
-        self.res_actual = self.camera.set_format(self.res_wanted[0], self.res_wanted[1], yuv420=0, fourcc='JPEG')
+        fmt = self.camera.set_format(self.res_wanted[0], self.res_wanted[1], fourcc=v4l2.V4L2_PIX_FMT_JPEG)
+        self.res_actual_x = fmt.fmt.pix.width
+        self.res_actual_y = fmt.fmt.pix.height
 
         self.camera.create_buffers(self.num_buffers)
         self.camera.queue_all_buffers()
@@ -69,16 +51,16 @@ class WebCam(object):
         if hasattr(self, 'camera'):
             self.camera.stop()
             self.camera.close()
-        if hasattr(self, 'dev'):
-            self.dev.close()
+        if hasattr(self, 'dev_fd'):
+            os.close(self.dev_fd)
 
     # get the ACTUAL webcam frame width
     def get_res_x(self):
-        return self.res_actual[0]
+        return self.res_actual_x
 
     # get the ACTUAL webcam frame height
     def get_res_y(self):
-        return self.res_actual[1]
+        return self.res_actual_y
 
     # get the most recent frame from the webcam, waiting if necessary, and throwing away stale frames if any
     # (the frame is a numpy array in BGR format)
@@ -98,24 +80,141 @@ class WebCam(object):
     # get one frame from the webcam buffer; the frame is not guaranteed to be the most recent frame available!
     # (the frame is a JPEG byte string)
     def get_one_frame(self):
-        return self.camera.read_and_queue()
+#        return self.camera.read_and_queue()
+        x = self.camera.read_and_queue()
+        return x
 
     # block until the webcam has at least one frame ready
     def block_until_frame_ready(self):
-        select.select((self.camera,), (), ())
+        select.select((self.dev_fd,), (), ())
 
     # query whether the webcam has at least one frame ready for us to read (non-blocking)
     def has_frames_available(self):
-        readable, writable, exceptional = select.select((self.camera,), (), (), 0.0)
+        readable, writable, exceptional = select.select((self.dev_fd,), (), (), 0.0)
         return (len(readable) != 0)
 
-    def is_ctrl_supported(self, id):
-        query = v4l2.v4l2_queryctrl()
-        query.id = id
+
+    def _set_exposure(self, level):
+        self._set_ctrl(v4l2.V4L2_CID_EXPOSURE, int(level), 'exposure level')
+
+    def _set_autogain(self, enable):
+        self._set_ctrl(v4l2.V4L2_CID_AUTOGAIN, int(enable), 'automatic gain')
+
+    def _set_ctrl(self, id, value, desc):
         try:
-            fcntl.ioctl(self.dev, v4l2.VIDIOC_QUERYCTRL, query)
+            data = v4l2.v4l2_control()
+            data.id    = id
+            data.value = value
+            self._v4l2_ioctl(v4l2.VIDIOC_S_CTRL, data)
         except (IOError, OSError):
-            return False
-        if ((query.flags & v4l2.V4L2_CTRL_FLAG_DISABLED) != 0):
-            return False
-        return True
+            print('WebCam: failed to set control: {}'.format(desc))
+
+    def _set_jpeg_quality(self, quality):
+        try:
+            # get current JPEG settings first; then change quality; then set
+            data = v4l2.v4l2_jpegcompression()
+            self._v4l2_ioctl(v4l2.VIDIOC_G_JPEGCOMP, data)
+            data.quality = quality
+            self._v4l2_ioctl(v4l2.VIDIOC_S_JPEGCOMP, data)
+        except (IOError, OSError):
+            print('WebCam: failed to set JPEG compression quality')
+
+    def _get_capture_format(self):
+        data = v4l2.v4l2_format()
+        data.type = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
+        self._v4l2_ioctl(v4l2.VIDIOC_G_FMT, data)
+        return data.fmt
+
+    def _v4l2_ioctl(self, req, arg):
+        fcntl.ioctl(self.dev_fd, req, arg)
+
+
+Buffer = namedtuple('Buffer', ' '.join(['length', 'start']))
+
+
+# TODO: eliminate this and integrate it into WebCam, if feasible & non-ugly
+class V4L2WebCam(object):
+
+    def __init__(self, dev_fd):
+        self.dev_fd     = dev_fd
+        self.buffers    = []
+
+    def __del__(self):
+        self._unmap()
+
+    def set_format(self, size_x, size_y, fourcc):
+        # size_x, size_y, fourcc='JPEG'
+
+        fmt = v4l2.v4l2_format()
+        fmt.type = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
+
+        self._v4l2_ioctl(v4l2.VIDIOC_G_FMT, fmt)
+
+        # TODO: double-check the sanity of some of the values below...
+        fmt.type                 = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
+        fmt.fmt.pix.width        = size_x
+        fmt.fmt.pix.height       = size_y
+        fmt.fmt.pix.bytesperline = 0
+        fmt.fmt.pix.pixelformat  = fourcc
+        fmt.fmt.pix.field        = v4l2.V4L2_FIELD_ANY
+
+        self._v4l2_ioctl(v4l2.VIDIOC_S_FMT, fmt)
+
+        return fmt
+
+    def create_buffers(self, buf_count):
+        reqbuf = v4l2.v4l2_requestbuffers()
+        reqbuf.count  = buf_count
+        reqbuf.type   = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
+        reqbuf.memory = v4l2.V4L2_MEMORY_MMAP
+        self._v4l2_ioctl(v4l2.VIDIOC_REQBUFS, reqbuf)
+        assert (reqbuf.count > 0)
+
+        for idx in range(reqbuf.count):
+            buf = v4l2.v4l2_buffer()
+            buf.index  = idx
+            buf.type   = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
+            buf.memory = v4l2.V4L2_MEMORY_MMAP
+            self._v4l2_ioctl(v4l2.VIDIOC_QUERYBUF, buf)
+
+            ptr = mmap.mmap(self.dev_fd, buf.length, access=mmap.ACCESS_WRITE, offset=buf.m.offset)
+            self.buffers += [Buffer(length=buf.length, start=ptr)]
+
+        self.buf_count = reqbuf.count
+
+    def queue_all_buffers(self):
+        for idx in range(self.buf_count):
+            buf = v4l2.v4l2_buffer()
+            buf.index  = idx
+            buf.type   = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
+            buf.memory = v4l2.V4L2_MEMORY_MMAP
+            self._v4l2_ioctl(v4l2.VIDIOC_QBUF, buf)
+
+    def start(self):
+        self._v4l2_ioctl(v4l2.VIDIOC_STREAMON, ctypes.c_int(int(v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE)))
+
+    def stop(self):
+        self._v4l2_ioctl(v4l2.VIDIOC_STREAMOFF, ctypes.c_int(int(v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE)))
+
+    def read_and_queue(self):
+        buf = v4l2.v4l2_buffer()
+        buf.type   = v4l2.V4L2_BUF_TYPE_VIDEO_CAPTURE
+        buf.memory = v4l2.V4L2_MEMORY_MMAP
+        self._v4l2_ioctl(v4l2.VIDIOC_DQBUF, buf)
+
+        result = self.buffers[buf.index].start.read(buf.bytesused)
+        self.buffers[buf.index].start.seek(0)
+
+        return result
+
+    def close(self):
+        self._unmap()
+
+
+    def _unmap(self):
+        for buf in self.buffers:
+            buf.start.close()
+        self.buffers = []
+
+    def _v4l2_ioctl(self, req, arg):
+        fcntl.ioctl(self.dev_fd, req, arg)


### PR DESCRIPTION
We do all the crap that v4l2capture used to do in C in Python now, and it works great!

Testing confirms the workingness, and the greatness thereof.